### PR TITLE
Update Jay Carr URL

### DIFF
--- a/planet/nottinghack/config.ini
+++ b/planet/nottinghack/config.ini
@@ -148,7 +148,7 @@ name = Martin Raynsford
 face = martin.png
 faceheight = 55
 
-[http://blog.teario.com/?feed=rss2]
+[http://ghost.teario.com/rss]
 name = Jay Carr
 face = jay.png
 faceheight = 77


### PR DESCRIPTION
Changed Jay Carr url from http://blog.teario.com/?feed=rss2 to http://ghost.teario.com/rss
