### PR TITLE
Calendar plugins: removed "full" parameter and changed from https to http GET call

### DIFF
--- a/public_html/wp-content/plugins/gl-gcal-widget/gl-gcal-widget.php
+++ b/public_html/wp-content/plugins/gl-gcal-widget/gl-gcal-widget.php
@@ -14,7 +14,7 @@ class GL_Cal extends WP_Widget {
 	
 	//private $feed_url = 'http://www.google.com/calendar/feeds/info%40nottinghack.org.uk/private-acbf60a032394b53e3caae31e5c725eb/';   // old API call
 	
-	private $feed_url = 'https://www.google.com/calendar/feeds/info%40nottinghack.org.uk/public/basic'; // April 2015 API call
+	private $feed_url = 'http://www.google.com/calendar/feeds/info%40nottinghack.org.uk/public/basic'; // April 2015 API call
 	function GL_Cal() {
 		// widget actual processes
 		$widget_ops = array('classname' => 'widget_gl_cal', 'description' => 'Provides agenda of upcoming events' );

--- a/public_html/wp-content/plugins/gl-gcal-widget/gl-gcal-widget.php
+++ b/public_html/wp-content/plugins/gl-gcal-widget/gl-gcal-widget.php
@@ -14,7 +14,7 @@ class GL_Cal extends WP_Widget {
 	
 	//private $feed_url = 'http://www.google.com/calendar/feeds/info%40nottinghack.org.uk/private-acbf60a032394b53e3caae31e5c725eb/';   // old API call
 	
-	private $feed_url = 'http://www.google.com/calendar/feeds/info%40nottinghack.org.uk/public/basic'; // April 2015 API call
+	private $feed_url = 'http://www.google.com/calendar/feeds/info%40nottinghack.org.uk/public/basic/'; // April 2015 API call
 	function GL_Cal() {
 		// widget actual processes
 		$widget_ops = array('classname' => 'widget_gl_cal', 'description' => 'Provides agenda of upcoming events' );
@@ -56,7 +56,8 @@ class GL_Cal extends WP_Widget {
 		global $current_user;
 		extract( $args );
 		
-		$xml_url = $this->feed_url . 'full?max-results=' . $instance['show_num'] . '&futureevents=true&orderby=starttime&sortorder=a&singleevents=true';
+		//$xml_url = $this->feed_url . 'full?max-results=' . $instance['show_num'] . '&futureevents=true&orderby=starttime&sortorder=a&singleevents=true';
+		$xml_url = $this->feed_url . '?max-results=' . $instance['show_num'] . '&futureevents=true&orderby=starttime&sortorder=a&singleevents=true';
 		$xml = file_get_contents( $xml_url );
 		
 		# check that we got something!

--- a/public_html/wp-content/plugins/gl-google-calendar/gl-google-calendar.php
+++ b/public_html/wp-content/plugins/gl-google-calendar/gl-google-calendar.php
@@ -62,7 +62,7 @@ function gl_google_calendar( $content ) {
 	// old google calendar API call
 	//$feed_url = 'http://www.google.com/calendar/feeds/info%40nottinghack.org.uk/private-acbf60a032394b53e3caae31e5c725eb/';
 	// April 2015 API call
-	$feed_url = 'http://www.google.com/calendar/feeds/info%40nottinghack.org.uk/public/basic';
+	$feed_url = 'http://www.google.com/calendar/feeds/info%40nottinghack.org.uk/public/basic/';
 	
 	# If user has clicked on next/prev month links, set the stamp appropriately
 	if ( isset( $_GET['gl_show'] ) ) {
@@ -98,7 +98,8 @@ function gl_google_calendar( $content ) {
 	$end = $nextyear . '-' . $nextmonth . '-01T00:00:00';
 	
 	# Generate URL and get XML from Google
-	$xml_url = $feed_url . 'full?start-min=' . $start . '&start-max=' . $end; 
+	//$xml_url = $feed_url . 'full?start-min=' . $start . '&start-max=' . $end; 
+	$xml_url = $feed_url . '?start-min=' . $start . '&start-max=' . $end; 
 	$xml = file_get_contents( $xml_url );
 	#echo($xml_url);
 	

--- a/public_html/wp-content/plugins/gl-google-calendar/gl-google-calendar.php
+++ b/public_html/wp-content/plugins/gl-google-calendar/gl-google-calendar.php
@@ -62,7 +62,7 @@ function gl_google_calendar( $content ) {
 	// old google calendar API call
 	//$feed_url = 'http://www.google.com/calendar/feeds/info%40nottinghack.org.uk/private-acbf60a032394b53e3caae31e5c725eb/';
 	// April 2015 API call
-	$feed_url = 'https://www.google.com/calendar/feeds/info%40nottinghack.org.uk/public/basic';
+	$feed_url = 'http://www.google.com/calendar/feeds/info%40nottinghack.org.uk/public/basic';
 	
 	# If user has clicked on next/prev month links, set the stamp appropriately
 	if ( isset( $_GET['gl_show'] ) ) {


### PR DESCRIPTION
when I now manually assemble the URL in the browser as the script would I get a roughly xml-shaped response (with html_encoded specialchars) - so should work on the site itself too
