### PR TITLE
fix negative days for overdue tasks

### DIFF
--- a/public_html/tools/slack/trello2slack.php
+++ b/public_html/tools/slack/trello2slack.php
@@ -178,7 +178,7 @@ function dueText($days) {
 		$string = "was due yesterday!";
 	}
 	elseif ($days < -1) {
-		$string = "was due " . $days . " days ago";
+		$string = "was due " . abs($days) . " days ago";
 	}
 
 	return $string;


### PR DESCRIPTION
This is a fix for negative days appearing in the message, eg: "was due -2 days ago"
